### PR TITLE
Allow custom log resource for Msk Cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Resources:
         KmsKeyModule: !GetAtt 'Key.Outputs.StackName' # optional
         BastionModule: !GetAtt 'Bastion.Outputs.StackName' # optional
         AlertingModule: !GetAtt 'Alerting.Outputs.StackName' # optional
-        LogModule: !Ref LogGroup # optional
         NumberOfBrokerNodes: !GetAtt 'Vpc.Outputs.NumberOfAvailabilityZones' # required
         KafkaVersion: '2.2.1' # optional
         InstanceType: 'kafka.t3.small' # optional
@@ -88,13 +87,6 @@ none
     <tr>
       <td>AlertingModule</td>
       <td>Stack name of <a href="https://www.npmjs.com/package/@cfn-modules/alerting">alerting module</a></td>
-      <td></td>
-      <td>no</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>LogModule</td>
-      <td>Log Group <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html">resource</a></td>
       <td></td>
       <td>no</td>
       <td></td>

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Resources:
         KmsKeyModule: !GetAtt 'Key.Outputs.StackName' # optional
         BastionModule: !GetAtt 'Bastion.Outputs.StackName' # optional
         AlertingModule: !GetAtt 'Alerting.Outputs.StackName' # optional
+        LogModule: !Ref LogGroup # optional
         NumberOfBrokerNodes: !GetAtt 'Vpc.Outputs.NumberOfAvailabilityZones' # required
         KafkaVersion: '2.2.1' # optional
         InstanceType: 'kafka.t3.small' # optional
@@ -87,6 +88,13 @@ none
     <tr>
       <td>AlertingModule</td>
       <td>Stack name of <a href="https://www.npmjs.com/package/@cfn-modules/alerting">alerting module</a></td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>LogModule</td>
+      <td>Log Group <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html">resource</a></td>
       <td></td>
       <td>no</td>
       <td></td>

--- a/module.yml
+++ b/module.yml
@@ -32,10 +32,6 @@ Parameters:
     Description: 'Optional but recommended stack name of alerting module.'
     Type: String
     Default: ''
-  LogModule:
-    Description: 'Custom supplied logging module.'
-    Type: String
-    Default: ''
   NumberOfBrokerNodes:
     Description: 'The number of broker nodes you want in the Amazon MSK cluster. You can submit an update to increase the number of broker nodes in a cluster. Has to be a multiple of the private subnets in your VPC.'
     Type: Number
@@ -73,12 +69,12 @@ Conditions:
   HasKmsKeyModule: !Not [!Equals [!Ref KmsKeyModule, '']]
   HasBastionModule: !Not [!Equals [!Ref BastionModule, '']]
   HasAlertingModule: !Not [!Equals [!Ref AlertingModule, '']]
-  HasLogModule: !Not [!Equals [!Ref LogModule, '']]
   HasMSKConfiguration: !Not [!Equals [!Ref MSKConfigurationArn, '']]
 Resources:
   LogGroup:
     Type: 'AWS::Logs::LogGroup'
     Properties:
+      LogGroupName: !Join ['', ['/aws/vendedlogs/cfn-modules-msk-', !Select [2, !Split ['/', !Ref 'AWS::StackId']]]]
       RetentionInDays: !Ref LogsRetentionInDays
   SecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
@@ -156,7 +152,7 @@ Resources:
         BrokerLogs:
           CloudWatchLogs:
             Enabled: true
-            LogGroup: !If [HasLogModule, !Ref LogModule, !Ref LogGroup ]
+            LogGroup: !Ref LogModule
       NumberOfBrokerNodes: !Ref NumberOfBrokerNodes
 Outputs:
   ModuleId:

--- a/module.yml
+++ b/module.yml
@@ -152,7 +152,7 @@ Resources:
         BrokerLogs:
           CloudWatchLogs:
             Enabled: true
-            LogGroup: !Ref LogModule
+            LogGroup: !Ref LogGroup
       NumberOfBrokerNodes: !Ref NumberOfBrokerNodes
 Outputs:
   ModuleId:

--- a/module.yml
+++ b/module.yml
@@ -32,6 +32,10 @@ Parameters:
     Description: 'Optional but recommended stack name of alerting module.'
     Type: String
     Default: ''
+  LogModule:
+    Description: 'Custom supplied logging module.'
+    Type: String
+    Default: ''
   NumberOfBrokerNodes:
     Description: 'The number of broker nodes you want in the Amazon MSK cluster. You can submit an update to increase the number of broker nodes in a cluster. Has to be a multiple of the private subnets in your VPC.'
     Type: Number
@@ -69,6 +73,7 @@ Conditions:
   HasKmsKeyModule: !Not [!Equals [!Ref KmsKeyModule, '']]
   HasBastionModule: !Not [!Equals [!Ref BastionModule, '']]
   HasAlertingModule: !Not [!Equals [!Ref AlertingModule, '']]
+  HasLogModule: !Not [!Equals [!Ref LogModule, '']]
   HasMSKConfiguration: !Not [!Equals [!Ref MSKConfigurationArn, '']]
 Resources:
   LogGroup:
@@ -151,7 +156,7 @@ Resources:
         BrokerLogs:
           CloudWatchLogs:
             Enabled: true
-            LogGroup: !Ref LogGroup
+            LogGroup: !If [HasLogModule, !Ref LogModule, !Ref LogGroup ]
       NumberOfBrokerNodes: !Ref NumberOfBrokerNodes
 Outputs:
   ModuleId:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

fixes cfn-modules/msk-cluster#6

Allows user so specify log resource in  /aws/vendedlogs/ log group. See linked issue:

